### PR TITLE
Behat files are feature contexts and default clear

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,8 @@ elixir.extend('behat', function(baseDir, options) {
 
     this.registerWatcher('behat', [
         baseDir + '/**/*+Context.php',
+        baseDir + '/**/*.feature',
+        'resources/**/*.php',
         'app/**/*.php'
     ], 'tdd');
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ elixir.extend('behat', function(baseDir, options) {
 
     baseDir = baseDir || 'tests';
     options = _.extend({
-        clear: true, notify: true
+        clear: false, notify: true
     }, options);
 
     gulp.task('behat', function() {
@@ -40,7 +40,7 @@ elixir.extend('behat', function(baseDir, options) {
     this.queueTask('behat');
 
     this.registerWatcher('behat', [
-        baseDir + '/**/*+(Test|Cept|Cest).php',
+        baseDir + '/**/*+Context.php',
         'app/**/*.php'
     ], 'tdd');
 


### PR DESCRIPTION
The original line looked for changes in PhpUnit and codeception changes. Context.php files are updated when behat changes are made. Additionally to ensure compatibility with additional command lines, the clear option default should be false.
